### PR TITLE
Migrate from StoreKit 1 receipt validation to StoreKit 2 JWS transact…

### DIFF
--- a/Sources/GoMarketMe/GoMarketMe.swift
+++ b/Sources/GoMarketMe/GoMarketMe.swift
@@ -119,27 +119,38 @@ public class GoMarketMe: NSObject, ObservableObject {
         }
     }
 
+    // MARK: - Transaction Listening
+
     private func listenForTransactions() {
+        updatesTask?.cancel()
+        let capturedState = captureEventState()
         updatesTask = Task.detached(priority: .background) {
             for await result in Transaction.updates {
+                guard !Task.isCancelled else { break }
                 switch result {
                 case .verified(let transaction):
-                    let products = await self.fetchProducts(for: [transaction.productID])
-                    await self.sendDetails(transactions: [result.jwsRepresentation], products: products)
+                    let products = await Self.fetchProducts(for: [transaction.productID])
+                    await Self.sendDetails(
+                        transactions: [result.jwsRepresentation],
+                        products: products,
+                        state: capturedState
+                    )
                     await transaction.finish()
-                case .unverified(let transaction, _):
-                    let products = await self.fetchProducts(for: [transaction.productID])
-                    await self.sendDetails(transactions: [result.jwsRepresentation], products: products)
+                case .unverified:
+                    break
                 }
             }
         }
     }
 
     public func syncAllTransactions() async {
-        await processAllTransactions()
+        let state = captureEventState()
+        await Self.performSync(state: state)
     }
 
-    private nonisolated func processAllTransactions() async {
+    // MARK: - Bulk Transaction Sync
+
+    private nonisolated static func performSync(state: EventState) async {
         var productIDs = Set<String>()
         var jwsTransactions = [String]()
         var verifiedTransactions = [Transaction]()
@@ -150,21 +161,51 @@ public class GoMarketMe: NSObject, ObservableObject {
                 productIDs.insert(transaction.productID)
                 jwsTransactions.append(result.jwsRepresentation)
                 verifiedTransactions.append(transaction)
-            case .unverified(let transaction, _):
-                productIDs.insert(transaction.productID)
-                jwsTransactions.append(result.jwsRepresentation)
+            case .unverified:
+                break
             }
         }
 
         guard !productIDs.isEmpty else { return }
 
         let products = await fetchProducts(for: Array(productIDs))
-        await sendDetails(transactions: jwsTransactions, products: products)
+        await sendDetails(transactions: jwsTransactions, products: products, state: state)
 
         for transaction in verifiedTransactions {
             await transaction.finish()
         }
     }
+
+    private func processAllTransactions() async {
+        let state = captureEventState()
+        await Self.performSync(state: state)
+    }
+
+    // MARK: - State Capture
+
+    private struct EventState: Sendable {
+        let apiKey: String
+        let affiliateCampaignCode: String
+        let deviceId: String
+        let packageName: String
+        let sdkType: String
+        let sdkVersion: String
+        let eventUrl: URL
+    }
+
+    private func captureEventState() -> EventState {
+        EventState(
+            apiKey: apiKey,
+            affiliateCampaignCode: affiliateCampaignCode,
+            deviceId: deviceId,
+            packageName: packageName,
+            sdkType: sdkType,
+            sdkVersion: sdkVersion,
+            eventUrl: eventUrl
+        )
+    }
+
+    // MARK: - SDK Initialization
 
     private func postSDKInitialization(apiKey: String) async throws {
         var request = URLRequest(url: sdkInitializationUrl)
@@ -176,6 +217,8 @@ public class GoMarketMe: NSObject, ObservableObject {
             markSDKAsInitialized()
         }
     }
+
+    // MARK: - System Info
 
     private func getSystemInfo() -> [String: Any] {
         var systemInfo = [String: Any]()
@@ -195,7 +238,7 @@ public class GoMarketMe: NSObject, ObservableObject {
             let screen = windowScene.screen
             windowInfo["devicePixelRatio"] = screen.scale
             windowInfo["width"] = screen.bounds.width * screen.scale
-            windowInfo["height"] = screen.bounds.height
+            windowInfo["height"] = screen.bounds.height * screen.scale
         }
         systemInfo["window_info"] = windowInfo
         systemInfo["time_zone"] = TimeZone.current.identifier
@@ -252,6 +295,8 @@ public class GoMarketMe: NSObject, ObservableObject {
         }
     }
 
+    // MARK: - Helpers
+
     private var isSimulator: Bool {
         #if targetEnvironment(simulator)
         return true
@@ -268,7 +313,9 @@ public class GoMarketMe: NSObject, ObservableObject {
         UserDefaults.standard.set(true, forKey: sdkInitializedKey)
     }
 
-    private func fetchProducts(for productIDs: [String]) async -> [Product] {
+    // MARK: - Product & Event (nonisolated)
+
+    private nonisolated static func fetchProducts(for productIDs: [String]) async -> [Product] {
         do {
             return try await Product.products(for: productIDs)
         } catch {
@@ -277,7 +324,7 @@ public class GoMarketMe: NSObject, ObservableObject {
         }
     }
 
-    private func sendDetails(transactions: [String], products: [Product]) async {
+    private nonisolated static func sendDetails(transactions: [String], products: [Product], state: EventState) async {
 
         func subscriptionUnitString(_ unit: Product.SubscriptionPeriod.Unit) -> String {
             switch unit {
@@ -298,10 +345,10 @@ public class GoMarketMe: NSObject, ObservableObject {
         for product in products {
             let currencyCode = product.priceFormatStyle.currencyCode
             let localeId = NSLocale.localeIdentifier(fromComponents: [NSLocale.Key.currencyCode.rawValue: currencyCode])
-            let currencySymbol = NSLocale(localeIdentifier: localeId).displayName(forKey: .currencySymbol, value: currencyCode) ?? currencyCode
+            let currencySymbol = NSLocale(localeIdentifier: localeId).object(forKey: .currencySymbol) as? String ?? currencyCode
 
             var productInfo: [String: Any] = [
-                "packageName": packageName,
+                "packageName": state.packageName,
                 "productID": product.id,
                 "productTitle": product.displayName,
                 "productDescription": product.description,
@@ -333,20 +380,20 @@ public class GoMarketMe: NSObject, ObservableObject {
         }
         requestData["products"] = productsArray
 
-        await self.sendEventToServer(eventType: "transactions", body: requestData)
+        await sendEventToServer(eventType: "transactions", body: requestData, state: state)
     }
 
-    private func sendEventToServer(eventType: String, body: [String: Any]) async {
-        var request = URLRequest(url: eventUrl)
+    private nonisolated static func sendEventToServer(eventType: String, body: [String: Any], state: EventState) async {
+        var request = URLRequest(url: state.eventUrl)
         request.httpMethod = "POST"
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.addValue(affiliateCampaignCode, forHTTPHeaderField: "x-affiliate-campaign-code")
-        request.addValue(self.apiKey, forHTTPHeaderField: "x-api-key")
-        request.addValue(deviceId, forHTTPHeaderField: "x-device-id")
+        request.addValue(state.affiliateCampaignCode, forHTTPHeaderField: "x-affiliate-campaign-code")
+        request.addValue(state.apiKey, forHTTPHeaderField: "x-api-key")
+        request.addValue(state.deviceId, forHTTPHeaderField: "x-device-id")
         request.addValue(eventType, forHTTPHeaderField: "x-event-type")
-        request.addValue(packageName, forHTTPHeaderField: "x-package-name")
-        request.addValue(sdkType, forHTTPHeaderField: "x-sdk-type")
-        request.addValue(sdkVersion, forHTTPHeaderField: "x-sdk-version")
+        request.addValue(state.packageName, forHTTPHeaderField: "x-package-name")
+        request.addValue(state.sdkType, forHTTPHeaderField: "x-sdk-type")
+        request.addValue(state.sdkVersion, forHTTPHeaderField: "x-sdk-version")
         request.addValue("app_store", forHTTPHeaderField: "x-source-name")
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
         do {

--- a/Sources/GoMarketMe/GoMarketMe.swift
+++ b/Sources/GoMarketMe/GoMarketMe.swift
@@ -9,7 +9,7 @@ public struct GoMarketMeAffiliateMarketingData: Decodable {
     public let affiliateCampaignCode: String
     public let deviceId: String
     public let offerCode: String?
-    
+
     enum CodingKeys: String, CodingKey {
         case campaign
         case affiliate
@@ -26,7 +26,7 @@ public struct Campaign: Decodable {
     public let status: String
     public let type: String
     public let publicLinkUrl: String?
-    
+
     enum CodingKeys: String, CodingKey {
         case id
         case name
@@ -44,7 +44,7 @@ public struct Affiliate: Decodable {
     public let instagramAccount: String
     public let tiktokAccount: String
     public let xAccount: String
-    
+
     enum CodingKeys: String, CodingKey {
         case id
         case firstName = "first_name"
@@ -59,19 +59,15 @@ public struct Affiliate: Decodable {
 public struct SaleDistribution: Decodable {
     public let platformPercentage: String
     public let affiliatePercentage: String
-    
+
     enum CodingKeys: String, CodingKey {
         case platformPercentage = "platform_percentage"
         case affiliatePercentage = "affiliate_percentage"
     }
 }
 
-public struct GoMarketMeVerifyReceiptData: Decodable {
-    public let is_valid: Bool
-    public let product_ids: [String]
-}
-
-public class GoMarketMe: NSObject, ObservableObject, SKRequestDelegate {
+@MainActor
+public class GoMarketMe: NSObject, ObservableObject {
 
     public static let shared = GoMarketMe()
     private let sdkInitializedKey = "GOMARKETME_SDK_INITIALIZED"
@@ -80,20 +76,16 @@ public class GoMarketMe: NSObject, ObservableObject, SKRequestDelegate {
     private var apiKey: String = ""
     private let sdkInitializationUrl = URL(string: "https://4v9008q1a5.execute-api.us-west-2.amazonaws.com/prod/v1/sdk-initialization")!
     private let systemInfoUrl = URL(string: "https://4v9008q1a5.execute-api.us-west-2.amazonaws.com/prod/v1/mobile/system-info")!
-    private let verifyReceiptUrl = URL(string: "https://4v9008q1a5.execute-api.us-west-2.amazonaws.com/prod/v1/mobile/app-store-verify-receipt")!
     private let eventUrl = URL(string: "https://4v9008q1a5.execute-api.us-west-2.amazonaws.com/prod/v1/event")!
-    private var _affiliateCampaignCode: String = ""
-    private var _deviceId: String = ""
-    private var _packageName = ""
+    private var affiliateCampaignCode: String = ""
+    private var deviceId: String = ""
+    private var packageName = ""
     private var updatesTask: Task<Void, Never>?
-    
-    @Published public var affiliateMarketingData: GoMarketMeAffiliateMarketingData?
 
-    private var backgroundTaskID: UIBackgroundTaskIdentifier = UIBackgroundTaskIdentifier.invalid
+    @Published public var affiliateMarketingData: GoMarketMeAffiliateMarketingData?
 
     private override init() {
         super.init()
-        listenForTransactions()
     }
 
     public func initialize(apiKey: String) {
@@ -101,28 +93,25 @@ public class GoMarketMe: NSObject, ObservableObject, SKRequestDelegate {
 
         Task {
             do {
-                if !(await _isSDKInitialized()) {
-                    try await _postSDKInitialization(apiKey: apiKey)
+                if !isSDKInitialized() {
+                    try await postSDKInitialization(apiKey: apiKey)
                 }
 
-                let systemInfo = await _getSystemInfo()
-                _packageName = Bundle.main.bundleIdentifier ?? "Unknown"
+                let systemInfo = getSystemInfo()
+                packageName = Bundle.main.bundleIdentifier ?? "Unknown"
 
                 if let deviceInfo = systemInfo["device_info"] as? [String: Any],
-                let identifierForVendor = deviceInfo["identifierForVendor"] as? String {
-                    _deviceId = identifierForVendor
-                }
-                DispatchQueue.main.async {
-                    Task {
-                        do {
-                            self.affiliateMarketingData = try await self._postSystemInfo(data: systemInfo, apiKey: apiKey) // Update on the main thread
-                        } catch {
-                            print("Failed to post system info: \(error)")
-                            self.affiliateMarketingData = nil
-                        }
-                    }
+                   let identifierForVendor = deviceInfo["identifierForVendor"] as? String {
+                    deviceId = identifierForVendor
                 }
 
+                let data = await postSystemInfo(data: systemInfo, apiKey: apiKey)
+                self.affiliateMarketingData = data
+                if let data = data {
+                    self.affiliateCampaignCode = data.affiliateCampaignCode
+                }
+                listenForTransactions()
+                await processAllTransactions()
             } catch {
                 print("Initialization failed with error: \(error)")
                 affiliateMarketingData = nil
@@ -132,69 +121,98 @@ public class GoMarketMe: NSObject, ObservableObject, SKRequestDelegate {
 
     private func listenForTransactions() {
         updatesTask = Task.detached(priority: .background) {
-            var refreshReceiptNeeded = false
-            for await verificationResult in Transaction.all {
-                refreshReceiptNeeded = true
-                break
-            }
-            
-            if refreshReceiptNeeded {
-                await self.refreshReceipt()
+            for await result in Transaction.updates {
+                switch result {
+                case .verified(let transaction):
+                    let products = await self.fetchProducts(for: [transaction.productID])
+                    await self.sendDetails(transactions: [result.jwsRepresentation], products: products)
+                    await transaction.finish()
+                case .unverified(let transaction, _):
+                    let products = await self.fetchProducts(for: [transaction.productID])
+                    await self.sendDetails(transactions: [result.jwsRepresentation], products: products)
+                }
             }
         }
     }
 
     public func syncAllTransactions() async {
-        var refreshReceiptNeeded = false
+        await processAllTransactions()
+    }
+
+    private nonisolated func processAllTransactions() async {
+        var productIDs = Set<String>()
+        var jwsTransactions = [String]()
+        var verifiedTransactions = [Transaction]()
+
         for await result in Transaction.all {
-            refreshReceiptNeeded = true
-            break
+            switch result {
+            case .verified(let transaction):
+                productIDs.insert(transaction.productID)
+                jwsTransactions.append(result.jwsRepresentation)
+                verifiedTransactions.append(transaction)
+            case .unverified(let transaction, _):
+                productIDs.insert(transaction.productID)
+                jwsTransactions.append(result.jwsRepresentation)
+            }
         }
 
-        if refreshReceiptNeeded {
-            await self.refreshReceipt()
+        guard !productIDs.isEmpty else { return }
+
+        let products = await fetchProducts(for: Array(productIDs))
+        await sendDetails(transactions: jwsTransactions, products: products)
+
+        for transaction in verifiedTransactions {
+            await transaction.finish()
         }
     }
 
-    private func _postSDKInitialization(apiKey: String) async throws {
+    private func postSDKInitialization(apiKey: String) async throws {
         var request = URLRequest(url: sdkInitializationUrl)
         request.httpMethod = "POST"
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         request.addValue(apiKey, forHTTPHeaderField: "x-api-key")
         let (_, response) = try await URLSession.shared.data(for: request)
         if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 {
-            _markSDKAsInitialized()
+            markSDKAsInitialized()
         }
     }
 
-    private func _getSystemInfo() async -> [String: Any] {
+    private func getSystemInfo() -> [String: Any] {
         var systemInfo = [String: Any]()
         var deviceInfo = [String: Any]()
-        let device = await UIDevice.current
-        deviceInfo["systemName"] = await device.systemName
-        deviceInfo["systemVersion"] = await device.systemVersion
-        deviceInfo["model"] = await device.model
-        deviceInfo["localizedModel"] = await device.localizedModel
-        deviceInfo["identifierForVendor"] = await device.identifierForVendor?.uuidString
-        deviceInfo["isPhysicalDevice"] = !_isSimulator
+        let device = UIDevice.current
+        deviceInfo["systemName"] = device.systemName
+        deviceInfo["systemVersion"] = device.systemVersion
+        deviceInfo["model"] = device.model
+        deviceInfo["localizedModel"] = device.localizedModel
+        deviceInfo["identifierForVendor"] = device.identifierForVendor?.uuidString
+        deviceInfo["isPhysicalDevice"] = !isSimulator
         systemInfo["device_info"] = deviceInfo
         var windowInfo = [String: Any]()
-        let screen = await UIScreen.main
-        windowInfo["devicePixelRatio"] = await screen.scale
-        windowInfo["width"] = await screen.bounds.width * screen.scale
-        windowInfo["height"] = await screen.bounds.height
+        if let windowScene = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .first {
+            let screen = windowScene.screen
+            windowInfo["devicePixelRatio"] = screen.scale
+            windowInfo["width"] = screen.bounds.width * screen.scale
+            windowInfo["height"] = screen.bounds.height
+        }
         systemInfo["window_info"] = windowInfo
         systemInfo["time_zone"] = TimeZone.current.identifier
-        systemInfo["language_code"] = Locale.current.languageCode ?? "en"
+        if #available(iOS 16, *) {
+            systemInfo["language_code"] = Locale.current.language.languageCode?.identifier ?? "en"
+        } else {
+            systemInfo["language_code"] = Locale.current.languageCode ?? "en"
+        }
         return systemInfo
     }
 
-    private func _postSystemInfo(data: [String: Any], apiKey: String) async -> GoMarketMeAffiliateMarketingData? {
+    private func postSystemInfo(data: [String: Any], apiKey: String) async -> GoMarketMeAffiliateMarketingData? {
         var requestData = data
         requestData["sdk_type"] = sdkType
         requestData["sdk_version"] = sdkVersion
-        requestData["package_name"] = _packageName
-        
+        requestData["package_name"] = packageName
+
         do {
             let requestBody = try JSONSerialization.data(withJSONObject: requestData, options: [])
             var request = URLRequest(url: systemInfoUrl)
@@ -202,9 +220,9 @@ public class GoMarketMe: NSObject, ObservableObject, SKRequestDelegate {
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
             request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
             request.httpBody = requestBody
-            
+
             let (data, response) = try await URLSession.shared.data(for: request)
-            
+
             guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
                 if let httpResponse = response as? HTTPURLResponse {
                     print("HTTP error: Status code \(httpResponse.statusCode)")
@@ -213,13 +231,13 @@ public class GoMarketMe: NSObject, ObservableObject, SKRequestDelegate {
                 }
                 return nil
             }
-            
+
             if let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any], json.isEmpty {
                 return nil
             }
 
             let decoder = JSONDecoder()
-            
+
             do {
                 let affiliateData = try decoder.decode(GoMarketMeAffiliateMarketingData.self, from: data)
                 return affiliateData
@@ -227,63 +245,14 @@ public class GoMarketMe: NSObject, ObservableObject, SKRequestDelegate {
                 print("Error decoding response data: \(error.localizedDescription)")
                 return nil
             }
-            
+
         } catch {
             print("Error during system info posting: \(error.localizedDescription)")
             return nil
         }
     }
 
-    private func _postVerifyReceipt(encodedReceipt: String) async -> GoMarketMeVerifyReceiptData? {
-        
-        let requestData: [String: Any] = [
-            "package_name": _packageName,
-            "encoded_receipt": encodedReceipt
-        ]
-        
-        do {
-            let requestBody = try JSONSerialization.data(withJSONObject: requestData, options: [])
-            var request = URLRequest(url: verifyReceiptUrl)
-            request.httpMethod = "POST"
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-            request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
-            request.addValue(_deviceId, forHTTPHeaderField: "x-device-id")
-            request.setValue(sdkType, forHTTPHeaderField: "x-sdk-type")
-            request.setValue(sdkVersion, forHTTPHeaderField: "x-sdk-version")
-            request.httpBody = requestBody
-            
-            let (data, response) = try await URLSession.shared.data(for: request)
-            
-            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
-                if let httpResponse = response as? HTTPURLResponse {
-                    print("HTTP error: Status code \(httpResponse.statusCode)")
-                } else {
-                    print("Failed to send receipt for verification: Invalid HTTP response")
-                }
-                return nil
-            }
-            
-            if let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any], json.isEmpty {
-                return nil
-            }
-
-            let decoder = JSONDecoder()
-            
-            do {
-                let affiliateData = try decoder.decode(GoMarketMeVerifyReceiptData.self, from: data)
-                return affiliateData
-            } catch {
-                print("Error decoding response data: \(error.localizedDescription)")
-                return nil
-            }
-            
-        } catch {
-            print("Error during receipt validation posting: \(error.localizedDescription)")
-            return nil
-        }
-    }
-
-    private var _isSimulator: Bool {
+    private var isSimulator: Bool {
         #if targetEnvironment(simulator)
         return true
         #else
@@ -291,99 +260,24 @@ public class GoMarketMe: NSObject, ObservableObject, SKRequestDelegate {
         #endif
     }
 
-    private func _isSDKInitialized() async -> Bool {
+    private func isSDKInitialized() -> Bool {
         return UserDefaults.standard.bool(forKey: sdkInitializedKey)
     }
 
-    private func _markSDKAsInitialized() {
+    private func markSDKAsInitialized() {
         UserDefaults.standard.set(true, forKey: sdkInitializedKey)
     }
 
-    private func endBackgroundTask() {
-        let taskID = backgroundTaskID
-        backgroundTaskID = UIBackgroundTaskIdentifier.invalid
-        if taskID != .invalid {
-            UIApplication.shared.endBackgroundTask(taskID)
+    private func fetchProducts(for productIDs: [String]) async -> [Product] {
+        do {
+            return try await Product.products(for: productIDs)
+        } catch {
+            print("Failed to fetch products: \(error.localizedDescription)")
+            return []
         }
     }
 
-    private func refreshReceipt() async {
-        backgroundTaskID = UIApplication.shared.beginBackgroundTask(withName: "SKReceiptRefreshRequest") {
-            UIApplication.shared.endBackgroundTask(self.backgroundTaskID)
-            self.backgroundTaskID = .invalid
-        }
-
-        let request = SKReceiptRefreshRequest()
-        request.delegate = self
-        request.start()
-    }
-
-    public func requestDidFinish(_ request: SKRequest) {
-        Task {
-            defer {
-
-                request.cancel() // important
-                self.endBackgroundTask()
-            }
-
-            guard
-                let receiptURL = Bundle.main.appStoreReceiptURL,
-                let receiptData = try? Data(contentsOf: receiptURL)
-            else {
-                return
-            }
-
-            let encodedReceipt = receiptData.base64EncodedString()
-
-            guard let verificationResult = await self._postVerifyReceipt(encodedReceipt: encodedReceipt),
-                verificationResult.is_valid else {
-                return
-            }
-
-            var productIDs = Set(verificationResult.product_ids)
-
-            for await verificationResult in Transaction.all {
-                switch verificationResult {
-                case .verified(let transaction):
-                    productIDs.insert(transaction.productID)
-                case .unverified(let transaction, _):
-                    productIDs.insert(transaction.productID)
-                }
-            }
-
-            fetchProducts(for: Array(productIDs)) { products in
-                self._sendDetails(encodedReceipt, products: products)
-                // endBackgroundTask is already handled by `defer`
-            }
-        }
-    }
-
-    public func request(_ request: SKRequest, didFailWithError error: Error) {
-        print("SKReceiptRefreshRequest failed with error: \(error)")
-
-        if backgroundTaskID != .invalid {
-            UIApplication.shared.endBackgroundTask(backgroundTaskID)
-            backgroundTaskID = .invalid
-        }
-    }
-    
-    private func fetchProducts(for productIDs: [String], completion: @escaping ([Product]) -> Void) {
-        Task {
-            do {
-                let products = try await Product.products(for: productIDs)
-                DispatchQueue.main.async {
-                    completion(products)
-                }
-            } catch {
-                print("Failed to fetch products: \(error.localizedDescription)")
-                DispatchQueue.main.async {
-                    completion([])
-                }
-            }
-        }
-    }
-
-    private func _sendDetails(_ encodedReceipt: String, products: [Product]) {
+    private func sendDetails(transactions: [String], products: [Product]) async {
 
         func subscriptionUnitString(_ unit: Product.SubscriptionPeriod.Unit) -> String {
             switch unit {
@@ -396,21 +290,25 @@ public class GoMarketMe: NSObject, ObservableObject, SKRequestDelegate {
         }
 
         var requestData: [String: Any] = [
-            "encodedReceipt": encodedReceipt,
+            "transactions": transactions,
         ]
 
         var productsArray: [[String: Any]] = []
 
         for product in products {
+            let currencyCode = product.priceFormatStyle.currencyCode
+            let localeId = NSLocale.localeIdentifier(fromComponents: [NSLocale.Key.currencyCode.rawValue: currencyCode])
+            let currencySymbol = NSLocale(localeIdentifier: localeId).displayName(forKey: .currencySymbol, value: currencyCode) ?? currencyCode
+
             var productInfo: [String: Any] = [
-                "packageName": _packageName,
+                "packageName": packageName,
                 "productID": product.id,
                 "productTitle": product.displayName,
                 "productDescription": product.description,
                 "productPrice": product.displayPrice,
                 "productRawPrice": product.price,
-                "productCurrencyCode": product.priceFormatStyle.currencyCode ?? "",
-                "productCurrencySymbol": product.priceFormatStyle.currencyCode ?? "",
+                "productCurrencyCode": currencyCode,
+                "productCurrencySymbol": currencySymbol,
                 "hashCode": String(product.hashValue)
             ]
 
@@ -424,9 +322,9 @@ public class GoMarketMe: NSObject, ObservableObject, SKRequestDelegate {
                         "unit": subscriptionUnitString(introOffer.period.unit),
                         "value": introOffer.period.value
                     ],
-                    "paymentMode": introOffer.paymentMode.rawValue,		
+                    "paymentMode": introOffer.paymentMode.rawValue,
                     "periodCount": introOffer.periodCount,
-                    "currencyCode": product.priceFormatStyle.currencyCode ?? ""
+                    "currencyCode": product.priceFormatStyle.currencyCode
                 ]
                 productInfo["introOffer"] = introOfferDict
             }
@@ -435,30 +333,26 @@ public class GoMarketMe: NSObject, ObservableObject, SKRequestDelegate {
         }
         requestData["products"] = productsArray
 
-        self._sendEventToServer(eventType: "encoded-receipt", body: requestData)
+        await self.sendEventToServer(eventType: "transactions", body: requestData)
     }
 
-    private func _sendEventToServer(eventType: String, body: [String: Any], completion: (() -> Void)? = nil) {
+    private func sendEventToServer(eventType: String, body: [String: Any]) async {
         var request = URLRequest(url: eventUrl)
         request.httpMethod = "POST"
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.addValue(_affiliateCampaignCode, forHTTPHeaderField: "x-affiliate-campaign-code")
+        request.addValue(affiliateCampaignCode, forHTTPHeaderField: "x-affiliate-campaign-code")
         request.addValue(self.apiKey, forHTTPHeaderField: "x-api-key")
-        request.addValue(_deviceId, forHTTPHeaderField: "x-device-id")
+        request.addValue(deviceId, forHTTPHeaderField: "x-device-id")
         request.addValue(eventType, forHTTPHeaderField: "x-event-type")
-        request.addValue(_packageName, forHTTPHeaderField: "x-package-name")
+        request.addValue(packageName, forHTTPHeaderField: "x-package-name")
         request.addValue(sdkType, forHTTPHeaderField: "x-sdk-type")
         request.addValue(sdkVersion, forHTTPHeaderField: "x-sdk-version")
         request.addValue("app_store", forHTTPHeaderField: "x-source-name")
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
-        let task = URLSession.shared.dataTask(with: request) { data, response, error in
-            if let error = error {
-                print("Failed to send \(eventType): Network error: \(error.localizedDescription)")
-                return
-            }
-            let response = response as? HTTPURLResponse
-            completion?()
+        do {
+            let (_, _) = try await URLSession.shared.data(for: request)
+        } catch {
+            print("Failed to send \(eventType): Network error: \(error.localizedDescription)")
         }
-        task.resume()
     }
 }


### PR DESCRIPTION
  Migrate from StoreKit 1 receipt validation to StoreKit 2 JWS transactions


  Replace deprecated SKReceiptRefreshRequest and appStoreReceiptURL-based
  receipt validation with modern StoreKit 2 Transaction API.

  Changes:
  - Remove GoMarketMeVerifyReceiptData struct and /verify-receipt endpoint usage
  - Remove SKRequestDelegate conformance (requestDidFinish, didFailWithError)
  - Remove SKReceiptRefreshRequest and UIBackgroundTaskIdentifier management
  - Replace base64-encoded receipt with JWS signed transaction strings
  - Add Transaction.updates listener for real-time new purchase monitoring
  - Add Transaction.all bulk sync (processAllTransactions) for initial load
  - Add transaction.finish() calls for verified transactions
  - Change event type from "encoded-receipt" to "transactions"
  - Send product metadata (price, currency, intro offers) alongside transactions
  - Fix productCurrencySymbol to send actual symbol ($, €) instead of code (USD)
  - Add @MainActor to class for thread safety with @Published property
  - Replace deprecated UIScreen.main with UIWindowScene.screen
  - Replace deprecated Locale.current.languageCode with language.languageCode (iOS 16+)
  - Convert callback-based methods to async/await
  - Remove DispatchQueue.main.async wrappers (handled by @MainActor)
  - Remove underscore prefix from private method/property names